### PR TITLE
Run `live` on the MainActor, allow multiple `delegate` streams

### DIFF
--- a/Examples/LocationManager/Common/LocalSearchClient/Models.swift
+++ b/Examples/LocationManager/Common/LocalSearchClient/Models.swift
@@ -133,9 +133,9 @@ public struct Placemark: Equatable {
     self.subLocality = rawValue.subLocality
     self.subThoroughfare = rawValue.subThoroughfare
     self.subtitle =
-      rawValue.responds(to: #selector(getter:MKPlacemark.subtitle)) ? rawValue.subtitle : nil
+      rawValue.responds(to: #selector(getter: MKPlacemark.subtitle)) ? rawValue.subtitle : nil
     self.thoroughfare = rawValue.thoroughfare
-    self.title = rawValue.responds(to: #selector(getter:MKPlacemark.title)) ? rawValue.title : nil
+    self.title = rawValue.responds(to: #selector(getter: MKPlacemark.title)) ? rawValue.title : nil
   }
 
   public init(

--- a/Package.swift
+++ b/Package.swift
@@ -35,12 +35,12 @@ let package = Package(
   ]
 )
 
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings?.append(
-    .unsafeFlags([
-      "-Xfrontend", "-warn-concurrency",
-      "-Xfrontend", "-enable-actor-data-race-checks",
-    ])
-  )
-}
+//for target in package.targets {
+//  target.swiftSettings = target.swiftSettings ?? []
+//  target.swiftSettings?.append(
+//    .unsafeFlags([
+//      "-Xfrontend", "-warn-concurrency",
+//      "-Xfrontend", "-enable-actor-data-race-checks",
+//    ])
+//  )
+//}

--- a/Package.swift
+++ b/Package.swift
@@ -17,13 +17,15 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0")
+    .package(url: "https://github.com/pointfreeco/swift-dependencies", from: "1.0.0"),
+    .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.0.0"),
   ],
   targets: [
     .target(
       name: "ComposableCoreLocation",
       dependencies: [
-        .product(name: "Dependencies", package: "swift-dependencies")
+        .product(name: "Dependencies", package: "swift-dependencies"),
+        .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
       ]
     ),
     .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -34,3 +34,13 @@ let package = Package(
     ),
   ]
 )
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings?.append(
+    .unsafeFlags([
+      "-Xfrontend", "-warn-concurrency",
+      "-Xfrontend", "-enable-actor-data-race-checks",
+    ])
+  )
+}

--- a/Sources/ComposableCoreLocation/Dependencies.swift
+++ b/Sources/ComposableCoreLocation/Dependencies.swift
@@ -1,21 +1,13 @@
-//
-//  Dependencies.swift
-//  
-//
-//  Created by Roberto Casula on 18/10/22.
-//
-
 import Dependencies
-import Foundation
 
 extension DependencyValues {
-    public var locationManager: LocationManager {
-        get { self[LocationManager.self] }
-        set { self[LocationManager.self] = newValue }
-    }
+  public var locationManager: LocationManager {
+    get { self[LocationManager.self] }
+    set { self[LocationManager.self] = newValue }
+  }
 }
 
 extension LocationManager: DependencyKey {
-    public static let testValue = Self.failing
-    public static var liveValue = Self.live
+  public static let testValue = Self.failing
+  public static var liveValue = Self.live
 }

--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -177,11 +177,11 @@ import CoreLocation
 /// control, and even what happens when the request for their location fails. It is very easy to
 /// write these tests, and we can test deep, subtle properties of our application.
 ///
-public struct LocationManager {
+public struct LocationManager: Sendable {
   /// Actions that correspond to `CLLocationManagerDelegate` methods.
   ///
   /// See `CLLocationManagerDelegate` for more information.
-  public enum Action: Equatable {
+  public enum Action: Equatable, Sendable {
     case didChangeAuthorization(CLAuthorizationStatus)
 
     @available(tvOS, unavailable)
@@ -199,7 +199,7 @@ public struct LocationManager {
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    case didFailRanging(beaconConstraint: CLBeaconIdentityConstraint, error: Error)
+    case didFailRanging(beaconConstraint: BeaconConstraint, error: Error)
 
     case didFailWithError(Error)
 
@@ -241,7 +241,7 @@ public struct LocationManager {
     @available(macOS, unavailable)
     @available(tvOS, unavailable)
     @available(watchOS, unavailable)
-    case didRangeBeacons([Beacon], satisfyingConstraint: CLBeaconIdentityConstraint)
+    case didRangeBeacons([Beacon], satisfyingConstraint: BeaconConstraint)
   }
 
   public struct Error: Swift.Error, Equatable {

--- a/Sources/ComposableCoreLocation/Interface.swift
+++ b/Sources/ComposableCoreLocation/Interface.swift
@@ -252,11 +252,11 @@ public struct LocationManager {
     }
   }
 
-  public var accuracyAuthorization: () -> AccuracyAuthorization?
+  public var accuracyAuthorization: @Sendable () async -> AccuracyAuthorization?
 
-  public var authorizationStatus: () -> CLAuthorizationStatus
+  public var authorizationStatus: @Sendable () async -> CLAuthorizationStatus
 
-  public var delegate: @Sendable () -> AsyncStream<Action>
+  public var delegate: @Sendable () async -> AsyncStream<Action>
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
@@ -264,27 +264,27 @@ public struct LocationManager {
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
-  public var heading: () -> Heading?
+  public var heading: @Sendable () async -> Heading?
 
   @available(tvOS, unavailable)
-  public var headingAvailable: () -> Bool
+  public var headingAvailable: @Sendable () async -> Bool
 
   @available(macOS, unavailable)
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var isRangingAvailable: () -> Bool
+  public var isRangingAvailable: @Sendable () async -> Bool
 
-  public var location: () -> Location?
+  public var location: @Sendable () async -> Location?
 
-  public var locationServicesEnabled: () -> Bool
-
-  @available(tvOS, unavailable)
-  @available(watchOS, unavailable)
-  public var maximumRegionMonitoringDistance: () -> CLLocationDistance
+  public var locationServicesEnabled: @Sendable () async -> Bool
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var monitoredRegions: () -> Set<Region>
+  public var maximumRegionMonitoringDistance: @Sendable () async -> CLLocationDistance
+
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  public var monitoredRegions: @Sendable () async -> Set<Region>
 
   @available(tvOS, unavailable)
   public var requestAlwaysAuthorization: @Sendable () async -> Void
@@ -299,7 +299,7 @@ public struct LocationManager {
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)
-  public var significantLocationChangeMonitoringAvailable: () -> Bool
+  public var significantLocationChangeMonitoringAvailable: @Sendable () async -> Bool
 
   @available(tvOS, unavailable)
   @available(watchOS, unavailable)

--- a/Sources/ComposableCoreLocation/Models/Beacon.swift
+++ b/Sources/ComposableCoreLocation/Models/Beacon.swift
@@ -5,7 +5,7 @@ import CoreLocation
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-public struct Beacon: Hashable {
+public struct Beacon: Hashable, Sendable {
   public var accuracy: CLLocationAccuracy
   public var major: NSNumber
   public var minor: NSNumber

--- a/Sources/ComposableCoreLocation/Models/BeaconConstraint.swift
+++ b/Sources/ComposableCoreLocation/Models/BeaconConstraint.swift
@@ -1,0 +1,19 @@
+import ConcurrencyExtras
+import CoreLocation
+
+/// A value type wrapper for `CLBeaconIdentityConstraint`. This type is necessary to add `Sendable`
+/// conformance to `LocationManager.Action`.
+@available(macOS, unavailable)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+public struct BeaconConstraint: Hashable, Sendable {
+  @UncheckedSendable public private(set) var rawValue: CLBeaconIdentityConstraint
+
+  public init(rawValue: CLBeaconIdentityConstraint) {
+    self.rawValue = rawValue
+  }
+
+  public subscript<T>(dynamicMember keyPath: KeyPath<CLBeaconIdentityConstraint, T>) -> T {
+    self.rawValue[keyPath: keyPath]
+  }
+}

--- a/Sources/ComposableCoreLocation/Models/Heading.swift
+++ b/Sources/ComposableCoreLocation/Models/Heading.swift
@@ -2,7 +2,7 @@ import CoreLocation
 
 /// A value type wrapper for `CLHeading`. This type is necessary so that we can do equality checks
 /// and write tests against its values.
-public struct Heading: Hashable {
+public struct Heading: Hashable, Sendable {
   public var headingAccuracy: CLLocationDirection
   public var magneticHeading: CLLocationDirection
   public var timestamp: Date

--- a/Sources/ComposableCoreLocation/Models/Location.swift
+++ b/Sources/ComposableCoreLocation/Models/Location.swift
@@ -1,10 +1,11 @@
+import ConcurrencyExtras
 import CoreLocation
 
 /// A value type wrapper for `CLLocation`. This type is necessary so that we can do equality checks
 /// and write tests against its values.
 @dynamicMemberLookup
-public struct Location {
-  public let rawValue: CLLocation
+public struct Location: Sendable {
+  @UncheckedSendable public private(set) var rawValue: CLLocation
 
   public init(
     altitude: CLLocationDistance = 0,

--- a/Sources/ComposableCoreLocation/Models/Region.swift
+++ b/Sources/ComposableCoreLocation/Models/Region.swift
@@ -1,9 +1,10 @@
+import ConcurrencyExtras
 import CoreLocation
 
 /// A value type wrapper for `CLRegion`. This type is necessary so that we can do equality checks
 /// and write tests against its values.
-public struct Region: Hashable {
-  public let rawValue: CLRegion?
+public struct Region: Hashable, Sendable {
+  @UncheckedSendable public private(set) var rawValue: CLRegion?
 
   public var identifier: String
   public var notifyOnEntry: Bool

--- a/Sources/ComposableCoreLocation/Models/Visit.swift
+++ b/Sources/ComposableCoreLocation/Models/Visit.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import CoreLocation
 
 /// A value type wrapper for `CLVisit`. This type is necessary so that we can do equality checks
@@ -6,8 +7,8 @@ import CoreLocation
 @available(macOS, unavailable)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-public struct Visit: Hashable {
-  public let rawValue: CLVisit?
+public struct Visit: Hashable, Sendable {
+  @UncheckedSendable public private(set) var rawValue: CLVisit?
 
   public var arrivalDate: Date
   public var coordinate: CLLocationCoordinate2D


### PR DESCRIPTION
When testing the current (Swift Concurrency) approach, the delegate method calls were not being invoked, and after some investigation it seems the problem was related with the `RunLoop` in which the `CLLocationManager` was created. With the latest `Dependencies`/`TCA` implementations, dependencies' access isn't bound to the `@MainActor`, so code is run from arbitrary queues/threads spanning multiple RunLoops.

According to `CLLocationManager`'s [documentation](https://developer.apple.com/documentation/corelocation/cllocationmanager):

> "Core Location calls the methods of your delegate object using the `RunLoop` of the thread on which you initialized the `CLLocationManager` object.

By forcing the `LocationManager.live`'s `CLLocationManager` instance to be instantiated on the main `RunLoop` via `@MainActor`, the delegate methods are correctly invoked. To minimize problems, all `.live` instance APIs' closures were annotated with `@MainActor`.

Furthermore, as the `Dependencies` instances are shared and can be called from multiple places concurrently, the `LocationManagerDelegate` was updated to allow forwarding delegate calls to multiple streams provided via `delegate()`.

Ran `swift-format` and performed some cleanups.

Enabled swift concurrency warnings in `Package.swift`, added `Sendable` conformance where needed, and wrapped `CLLocation` types in `@UncheckedSendable` until properly annotated.

